### PR TITLE
Fix heredoc with pipes

### DIFF
--- a/src/cmd/cmd.h
+++ b/src/cmd/cmd.h
@@ -42,6 +42,7 @@ void	handle_cmd_input(struct s_shell *shell);
 # define PERM_URW_GR_OR 0644
 
 bool	setup_redirections(struct s_token *token);
+char *create_heredoc(char *delimiter);
 
 /*
  - Command executor

--- a/src/cmd/cmd_executor.c
+++ b/src/cmd/cmd_executor.c
@@ -67,10 +67,12 @@ void	fill_redirections(t_token *tokens)
 	token = tokens;
 	while (token != NULL && token->next != NULL)
 	{
-		if (token->type == T_REDIR_IN || token->type == T_HEREDOC)
-			token->infile = ms_strdup(token->next->cmd);
-		else if (token->type == T_REDIR_OUT || token->type == T_REDIR_APPEND)
-			token->outfile = ms_strdup(token->next->cmd);
+                if (token->type == T_REDIR_IN)
+                        token->infile = ms_strdup(token->next->cmd);
+                else if (token->type == T_HEREDOC)
+                        token->infile = create_heredoc(token->next->cmd);
+                else if (token->type == T_REDIR_OUT || token->type == T_REDIR_APPEND)
+                        token->outfile = ms_strdup(token->next->cmd);
 		token = token->next;
 	}
 }

--- a/src/parser/input_splitter.c
+++ b/src/parser/input_splitter.c
@@ -12,34 +12,6 @@
 
 #include "minishell.h"
 
-t_ulong	get_token_count(const char *input)
-{
-	t_ulong	i;
-	t_ulong	count;
-	bool	in_word;
-	char	quote;
-
-	i = 0;
-	count = 0;
-	in_word = false;
-	quote = '\0';
-	while (input[i])
-	{
-		if (quote == '\0' && ms_isquote(input[i]))
-			quote = input[i];
-		else if (input[i] == quote)
-			quote = '\0';
-		if (quote == '\0' && input[i] == ' ')
-			in_word = false;
-		else if (!in_word && (quote != '\0' || input[i] != ' '))
-		{
-			in_word = true;
-			count++;
-		}
-		i++;
-	}
-	return (count);
-}
 
 bool	is_sep(char ch)
 {
@@ -78,6 +50,46 @@ static t_ulong	get_token_end(const char *input, t_ulong i)
 	return (i);
 }
 
+t_ulong get_token_count(const char *input)
+{
+        t_ulong i;
+        t_ulong count;
+        char    quote;
+
+        i = 0;
+        count = 0;
+        while (input[i] != '\0')
+        {
+                while (ms_isspace(input[i]))
+                        i++;
+                if (input[i] == '\0')
+                        break ;
+                if (is_sep(input[i]))
+                {
+                        if ((input[i] == '>' && input[i + 1] == '>') ||
+                                (input[i] == '<' && input[i + 1] == '<'))
+                                i += 2;
+                        else
+                                i += 1;
+                }
+                else
+                {
+                        quote = '\0';
+                        while (input[i] != '\0')
+                        {
+                                if (quote == '\0' && ms_isquote(input[i]))
+                                        quote = input[i];
+                                else if (quote != '\0' && input[i] == quote)
+                                        quote = '\0';
+                                else if (quote == '\0' && (ms_isspace(input[i]) || is_sep(input[i])))
+                                        break ;
+                                i++;
+                        }
+                }
+                count++;
+        }
+        return (count);
+}
 char	**to_token_array(const char *input)
 {
 	t_ulong	i;

--- a/src/parser/token_cleaner.c
+++ b/src/parser/token_cleaner.c
@@ -30,17 +30,34 @@ void	clean_tokens(t_token *tokens)
 	t_token	*to_delete;
 
 	current = tokens;
-	while (current != NULL && current->next != NULL)
-	{
-		if (current->type == T_REDIR_IN || current->type == T_REDIR_OUT
-			|| current->type == T_REDIR_APPEND || current->type == T_HEREDOC)
-		{
-			to_delete = current->next;
-			current->next = to_delete->next;
-			free_token(to_delete);
-		}
-		current = current->next;
-	}
+       while (current != NULL && current->next != NULL)
+       {
+               if (current->type == T_REDIR_IN || current->type == T_REDIR_OUT
+                       || current->type == T_REDIR_APPEND || current->type == T_HEREDOC)
+               {
+                       to_delete = current->next;
+                       current->next = to_delete->next;
+                       if (to_delete->infile != NULL)
+                       {
+                               if (current->infile != NULL)
+                                       free(current->infile);
+                               current->infile = to_delete->infile;
+                               to_delete->infile = NULL;
+                       }
+                       if (to_delete->outfile != NULL)
+                       {
+                               if (current->outfile != NULL)
+                                       free(current->outfile);
+                               current->outfile = to_delete->outfile;
+                               to_delete->outfile = NULL;
+                       }
+                       if (to_delete->type == T_PIPE)
+                               current->type = T_PIPE;
+                       free_token(to_delete);
+               }
+               else
+                       current = current->next;
+       }
 }
 
 void	free_token_list(t_token *head)

--- a/test/heredoc/test_hd_basic.c
+++ b/test/heredoc/test_hd_basic.c
@@ -1,0 +1,38 @@
+#include "ms_assertions.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+static char *read_file(const char *path)
+{
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return NULL;
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc(size + 1);
+    fread(buf, 1, size, f);
+    buf[size] = '\0';
+    fclose(f);
+    return buf;
+}
+
+static int str_contains(const char *haystack, const char *needle)
+{
+    return strstr(haystack, needle) != NULL;
+}
+
+int main(void)
+{
+    int ms_status = system("printf 'cat <<EOF\\nhello\\nEOF\\nexit\\n' | ./minishell > ms_out.txt 2>&1");
+    int bash_status = system("printf 'cat <<EOF\\nhello\\nEOF\\n' | bash --noprofile --norc > bash_out.txt 2>&1");
+    char *ms = read_file("ms_out.txt");
+    char *bash = read_file("bash_out.txt");
+    ASSERT_TRUE(str_contains(ms, "hello"));
+    ASSERT_TRUE(str_contains(bash, "hello"));
+    ASSERT_TRUE(ms_status == 0);
+    ASSERT_TRUE(bash_status == 0);
+    free(ms);
+    free(bash);
+}

--- a/test/heredoc/test_hd_edge_cases.c
+++ b/test/heredoc/test_hd_edge_cases.c
@@ -1,0 +1,44 @@
+#include "ms_assertions.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+static char *read_file(const char *path)
+{
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return NULL;
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc(size + 1);
+    fread(buf, 1, size, f);
+    buf[size] = '\0';
+    fclose(f);
+    return buf;
+}
+
+static int str_contains(const char *haystack, const char *needle)
+{
+    return strstr(haystack, needle) != NULL;
+}
+
+int main(void)
+{
+    const char *script = "cat <<EOF\nline1\n$USER\n\nEOF\nexit\n";
+    FILE *f = fopen("tmp_edge.sh", "w");
+    fputs(script, f);
+    fclose(f);
+    int ms_status = system("./minishell < tmp_edge.sh > ms_edge.txt 2>&1");
+    int bash_status = system("bash --noprofile --norc < tmp_edge.sh > bash_edge.txt 2>&1");
+    char *ms = read_file("ms_edge.txt");
+    char *bash = read_file("bash_edge.txt");
+    ASSERT_TRUE(str_contains(ms, "line1"));
+    ASSERT_TRUE(str_contains(ms, getenv("USER")) || str_contains(ms, "$USER"));
+    ASSERT_TRUE(str_contains(bash, "line1"));
+    free(ms);
+    free(bash);
+    ASSERT_TRUE(ms_status == 0);
+    ASSERT_TRUE(bash_status == 0);
+    remove("tmp_edge.sh");
+}

--- a/test/heredoc/test_hd_multiple.c
+++ b/test/heredoc/test_hd_multiple.c
@@ -1,0 +1,43 @@
+#include "ms_assertions.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+static char *read_file(const char *path)
+{
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return NULL;
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc(size + 1);
+    fread(buf, 1, size, f);
+    buf[size] = '\0';
+    fclose(f);
+    return buf;
+}
+
+static int str_contains(const char *haystack, const char *needle)
+{
+    return strstr(haystack, needle) != NULL;
+}
+
+int main(void)
+{
+    const char *script = "cat <<EOF1 <<EOF2\nA\nEOF1\nB\nEOF2\nexit\n";
+    FILE *f = fopen("tmp_script.sh", "w");
+    fputs(script, f);
+    fclose(f);
+    int ms_status = system("./minishell < tmp_script.sh > ms_multi.txt 2>&1");
+    int bash_status = system("bash --noprofile --norc < tmp_script.sh > bash_multi.txt 2>&1");
+    char *ms = read_file("ms_multi.txt");
+    char *bash = read_file("bash_multi.txt");
+    ASSERT_TRUE(str_contains(bash, "B"));
+    ASSERT_TRUE(str_contains(ms, "B"));
+    ASSERT_TRUE(ms_status == 0);
+    ASSERT_TRUE(bash_status == 0);
+    free(ms);
+    free(bash);
+    remove("tmp_script.sh");
+}

--- a/test/heredoc/test_hd_pipe.c
+++ b/test/heredoc/test_hd_pipe.c
@@ -1,0 +1,43 @@
+#include "ms_assertions.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+static char *read_file(const char *path)
+{
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return NULL;
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc(size + 1);
+    fread(buf, 1, size, f);
+    buf[size] = '\0';
+    fclose(f);
+    return buf;
+}
+
+static int str_contains(const char *haystack, const char *needle)
+{
+    return strstr(haystack, needle) != NULL;
+}
+
+int main(void)
+{
+    const char *script = "cat <<EOF | grep hi\nhi there\nEOF\nexit\n";
+    FILE *f = fopen("tmp_pipe.sh", "w");
+    fputs(script, f);
+    fclose(f);
+    int ms_status = system("./minishell < tmp_pipe.sh > ms_pipe.txt 2>&1");
+    int bash_status = system("bash --noprofile --norc < tmp_pipe.sh > bash_pipe.txt 2>&1");
+    char *ms = read_file("ms_pipe.txt");
+    char *bash = read_file("bash_pipe.txt");
+    ASSERT_TRUE(str_contains(bash, "hi there"));
+    ASSERT_TRUE(str_contains(ms, "hi there"));
+    ASSERT_TRUE(ms_status == 0);
+    ASSERT_TRUE(bash_status == 0);
+    free(ms);
+    free(bash);
+    remove("tmp_pipe.sh");
+}


### PR DESCRIPTION
## Summary
- preserve pipe tokens when cleaning heredoc delimiters
- update heredoc cleanup to forward next token fields to the command

## Testing
- `export USER=codex && make testonly TESTS=test_hd_*`

------
https://chatgpt.com/codex/tasks/task_e_687ecaf18cc4832d836aefd48bbc3b61