### PR TITLE
Improve heredoc behavior and signal handling

### DIFF
--- a/src/cmd/heredoc.c
+++ b/src/cmd/heredoc.c
@@ -1,126 +1,147 @@
-/* ************************************************************************** */
-/*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   heredoc.c                                          :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: daniema3 <daniema3@student.42madrid.com    +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/07/25 13:29:19 by rexposit          #+#    #+#             */
-/*   Updated: 2025/07/25 18:58:55 by daniema3         ###   ########.fr       */
-/*                                                                            */
-/* ************************************************************************** */
-
 #include "minishell.h"
 
-void	write_heredoc_lines(int fd, char *delimiter)
+static bool     is_quoted(char *delim)
 {
-	char	*line;
-	t_shell	*shell;
+    t_ulong len;
 
-	shell = get_shell();
-	while (1)
-	{
-		line = readline("> ");
-		if (!line || ms_strequals(line, delimiter))
-		{
-			free(line);
-			break ;
-		}
-		line = expand(shell, line);
-		write(fd, line, ms_strlen(line));
-		write(fd, "\n", 1);
-		free(line);
-	}
+    len = ms_strlen(delim);
+    if (len < 2)
+        return (false);
+    if ((delim[0] == '\'' && delim[len - 1] == '\'')
+        || (delim[0] == '"' && delim[len - 1] == '"'))
+        return (true);
+    return (false);
 }
 
-char	*generate_tempfile_path(void)
+static char     *strip_quotes(char *delim)
 {
-	int		tmp_num;
-	int		fd;
-	char	*tmp_num_str;
-	char	*path;
+    t_ulong len;
 
-	tmp_num = 0;
-	while (true)
-	{
-		tmp_num_str = ms_itoa(tmp_num);
-		path = ms_strjoin(HD_TEMP_PATH, tmp_num_str, '\0');
-		free(tmp_num_str);
-		fd = open(path, O_CREAT | O_EXCL | O_RDWR, PERM_URW_GR_OR);
-		if (fd != -1)
-			return (close(fd), path);
-		free(path);
-		tmp_num++;
-	}
+    len = ms_strlen(delim);
+    if (is_quoted(delim))
+        return (ms_substr(delim, 1, len - 2));
+    return (ms_strdup(delim));
 }
 
-int	wait_heredoc_child(pid_t pid, char *path)
+static void     write_heredoc_lines(int fd, char *delim, bool exp_env)
 {
-	t_shell	*shell;
-	int		status;
+    char        *line;
+    t_shell     *shell;
 
-	shell = get_shell();
-	waitpid(pid, &status, 0);
-	shell->heredoc_pid = 0;
-	if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
-	{
-		shell->last_exit_code = 130;
-		unlink(path);
-		free(path);
-		rl_replace_line("", 0);
-		rl_on_new_line();
-		rl_redisplay();
-		return (1);
-	}
-	if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
-	{
-		shell->last_exit_code = WEXITSTATUS(status);
-		unlink(path);
-		free(path);
-		return (1);
-	}
-	return (0);
+    shell = get_shell();
+    while (true)
+    {
+        line = readline("> ");
+        if (!line || ms_strequals(line, delim))
+            return (free(line));
+        if (exp_env)
+            line = expand(shell, line);
+        write(fd, line, ms_strlen(line));
+        write(fd, "\n", 1);
+        free(line);
+    }
 }
 
-pid_t	fork_heredoc_process(char *delimiter, char *path, int fd)
+char    *generate_tempfile_path(void)
 {
-	pid_t	pid;
+    int         tmp_num;
+    int         fd;
+    char        *tmp_num_str;
+    char        *path;
 
-	pid = fork();
-	if (pid == -1)
-	{
-		close(fd);
-		free(path);
-		return (-1);
-	}
-	if (pid == 0)
-	{
-		signal(SIGINT, SIG_DFL);
-		write_heredoc_lines(fd, delimiter);
-		close(fd);
-		exit(0);
-	}
-	return (pid);
+    tmp_num = 0;
+    while (true)
+    {
+        tmp_num_str = ms_itoa(tmp_num);
+        path = ms_strjoin(HD_TEMP_PATH, tmp_num_str, '\0');
+        free(tmp_num_str);
+        fd = open(path, O_CREAT | O_EXCL | O_RDWR, PERM_URW_GR_OR);
+        if (fd != -1)
+            return (close(fd), path);
+        free(path);
+        tmp_num++;
+    }
 }
 
-char	*create_heredoc(char *delimiter)
+static int      hd_child_status(int status, char *path)
 {
-	char	*path;
-	int		fd;
-	t_shell	*shell;
-	pid_t	pid;
+    t_shell *shell;
 
-	shell = get_shell();
-	path = generate_tempfile_path();
-	fd = open(path, O_WRONLY | O_TRUNC);
-	if (fd == -1)
-		return (free(path), NULL);
-	pid = fork_heredoc_process(delimiter, path, fd);
-	if (pid == -1)
-		return (NULL);
-	shell->heredoc_pid = pid;
-	if (wait_heredoc_child(pid, path))
-		return (NULL);
-	close(fd);
-	return (path);
+    shell = get_shell();
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
+    {
+        shell->last_exit_code = 130;
+        unlink(path);
+        free(path);
+        rl_replace_line("", 0);
+        rl_on_new_line();
+        rl_redisplay();
+        return (1);
+    }
+    if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+    {
+        shell->last_exit_code = WEXITSTATUS(status);
+        unlink(path);
+        free(path);
+        return (1);
+    }
+    return (0);
 }
+
+static int      wait_heredoc_child(pid_t pid, char *path)
+{
+    int status;
+
+    waitpid(pid, &status, 0);
+    get_shell()->heredoc_pid = 0;
+    return (hd_child_status(status, path));
+}
+
+static pid_t    fork_hd_process(char *delim, char *path, int fd, bool exp_env)
+{
+    pid_t       pid;
+
+    pid = fork();
+    if (pid == -1)
+    {
+        close(fd);
+        free(path);
+        return (-1);
+    }
+    if (pid == 0)
+    {
+        signal(SIGINT, SIG_DFL);
+        signal(SIGQUIT, SIG_IGN);
+        write_heredoc_lines(fd, delim, exp_env);
+        close(fd);
+        exit(0);
+    }
+    return (pid);
+}
+
+char    *create_heredoc(char *delimiter)
+{
+    char        *path, *clean;
+    int         fd;
+    pid_t       pid;
+    bool        exp_env;
+    t_shell     *shell;
+
+    shell = get_shell();
+    exp_env = !is_quoted(delimiter);
+    clean = strip_quotes(delimiter);
+    path = generate_tempfile_path();
+    fd = open(path, O_WRONLY | O_TRUNC);
+    if (fd == -1)
+        return (free(path), free(clean), NULL);
+    pid = fork_hd_process(clean, path, fd, exp_env);
+    free(clean);
+    if (pid == -1)
+        return (NULL);
+    shell->heredoc_pid = pid;
+    if (wait_heredoc_child(pid, path))
+        return (NULL);
+    close(fd);
+    return (path);
+}
+

--- a/src/signal/signal_handler.c
+++ b/src/signal/signal_handler.c
@@ -31,23 +31,16 @@ static void	sig_handler(int signum)
 			rl_redisplay();
 		}
 	}
-	else if (signum == SIGQUIT)
-	{
-		rl_on_new_line();
-		rl_replace_line("  ", 0);
-		rl_redisplay();
-		rl_replace_line("", 0);
-		rl_redisplay();
-	}
 }
 
 void	init_sighandler(void)
 {
 	struct sigaction	sa;
 
-	sa.sa_handler = sig_handler;
-	sigemptyset(&sa.sa_mask);
-	sa.sa_flags = 0;
-	sigaction(SIGINT, &sa, NULL);
-	sigaction(SIGQUIT, &sa, NULL);
+        sa.sa_handler = sig_handler;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        sigaction(SIGINT, &sa, NULL);
+        sa.sa_handler = SIG_IGN;
+        sigaction(SIGQUIT, &sa, NULL);
 }


### PR DESCRIPTION
## Summary
- rewrite heredoc implementation to match bash behavior
- support quoted delimiters and optional variable expansion
- clean up heredoc signal handling
- ignore SIGQUIT globally

## Testing
- `make` *(builds nothing new)*
- `make test` *(fails: norminette/valgrind missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883d0f2d724832d84aee2f25a5bc2ec